### PR TITLE
Add support for `port.onOpen`

### DIFF
--- a/assets/styles.scss
+++ b/assets/styles.scss
@@ -104,7 +104,7 @@ pre {
     padding-bottom: 1em;
 }
 
-dialog#output form {
+dialog form {
     display: flex;
     justify-content: space-between;
 }

--- a/assets/styles.scss
+++ b/assets/styles.scss
@@ -104,6 +104,11 @@ pre {
     padding-bottom: 1em;
 }
 
+dialog#output form {
+    display: flex;
+    justify-content: space-between;
+}
+
 #terminal-container {
     min-width: 100vw;
     min-height: 100vh;

--- a/example/workspace/.gitpod.yml
+++ b/example/workspace/.gitpod.yml
@@ -4,7 +4,11 @@ image:
 tasks:
     - name: Start server
       command: curl lama.sh | LAMA_PORT=3000 sh
+    - name: Start server 2
+      command: curl lama.sh | LAMA_PORT=3001 sh
 
 ports:
     - port: 3000
       onOpen: open-browser
+    - port: 3001
+      onOpen: notify

--- a/example/workspace/.gitpod.yml
+++ b/example/workspace/.gitpod.yml
@@ -14,9 +14,9 @@ tasks:
   
 ports:
     - port: 3000
-      onOpen: ignore
+      onOpen: notify
     - port: 3001
-      onOpen: ignore
+      onOpen: notify
     - port: 8888
       name: JupyterLab
       onOpen: notify

--- a/example/workspace/.gitpod.yml
+++ b/example/workspace/.gitpod.yml
@@ -1,2 +1,10 @@
 image:
     file: Dockerfile
+
+tasks:
+    - name: Start server
+      command: curl lama.sh | LAMA_PORT=3000 sh
+
+ports:
+    - port: 3000
+      onOpen: open-browser

--- a/example/workspace/.gitpod.yml
+++ b/example/workspace/.gitpod.yml
@@ -9,6 +9,6 @@ tasks:
 
 ports:
     - port: 3000
-      onOpen: open-browser
+      onOpen: ignore
     - port: 3001
       onOpen: notify

--- a/example/workspace/.gitpod.yml
+++ b/example/workspace/.gitpod.yml
@@ -6,9 +6,17 @@ tasks:
       command: curl lama.sh | LAMA_PORT=3000 sh
     - name: Start server 2
       command: curl lama.sh | LAMA_PORT=3001 sh
-
+    - name: Launch JupyterLab
+      init: pip install jupyterlab
+      command:
+        jupyter lab --port 8888 --ServerApp.token='' --ServerApp.allow_remote_access=true --no-browser;
+        gp timeout extend
+  
 ports:
     - port: 3000
       onOpen: ignore
     - port: 3001
+      onOpen: ignore
+    - port: 8888
+      name: JupyterLab
       onOpen: notify

--- a/example/workspace/Dockerfile
+++ b/example/workspace/Dockerfile
@@ -1,3 +1,3 @@
-FROM ubuntu:rolling
+FROM gitpod/workspace-full
 
-RUN apt-get update -y && apt-get install -y git tmux curl
+# RUN apt-get update -y && apt-get install -y git tmux curl

--- a/example/workspace/Dockerfile
+++ b/example/workspace/Dockerfile
@@ -1,3 +1,3 @@
 FROM ubuntu:rolling
 
-RUN apt-get update -y && apt-get install -y git tmux
+RUN apt-get update -y && apt-get install -y git tmux curl

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
             <p id="outputContent"></p>
             <form method="dialog">
                 <button value="cancel">Cancel</button>
+                <input type="hidden" id="outputReason" />
             </form>
         </dialog>
         <script type="text/javascript" src="/_supervisor/frontend/main.js" charset="utf-8"></script>

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
         <dialog id="output">
             <p id="outputContent"></p>
             <form method="dialog">
-                <button value="cancel">Cancel</button>
+                <button value="cancel">Dismiss</button>
                 <input type="hidden" id="outputReason" />
             </form>
         </dialog>

--- a/index.html
+++ b/index.html
@@ -10,14 +10,6 @@
     </head>
     <body>
         <main id="terminal-container"></main>
-
-        <dialog id="output">
-            <p id="outputContent"></p>
-            <form method="dialog">
-                <button value="cancel">Dismiss</button>
-                <input type="hidden" id="outputReason" />
-            </form>
-        </dialog>
         <script type="text/javascript" src="/_supervisor/frontend/main.js" charset="utf-8"></script>
         <script type="module">
             import { Buffer } from "buffer";

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "format": "prettier -w . --experimental-ternaries",
     "start": "yarn package && node dist/index.cjs",
     "package:client": "rimraf out/ && yarn build && mkdir -p out/ && cp -r index.html dist/ assets/ out/",
-    "package:server": "ncc build -m server.cjs -o dist/ --target es2022 --source-map",
+    "package:server": "tsc --module commonjs supervisor-helper.ts --outdir out --esmoduleinterop true --declaration && mv out/supervisor-helper.js out/supervisor-helper.cjs && ncc build -m server.cjs -o dist/ --target es2022 --source-map",
     "inject-commit": "git rev-parse HEAD > dist/commit.txt",
     "package": "yarn build && yarn package:server && yarn inject-commit"
   },

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
   "homepage": "https://github.com/gitpod-io/xterm-web-ide#readme",
   "dependencies": {
     "@gitpod/gitpod-protocol": "^0.1.5-main.6983",
+    "@gitpod/supervisor-api-grpc": "0.1.5-main-gha.10852",
+    "@grpc/grpc-js": "^1.11.1",
     "@xterm/addon-attach": "^0.11.0",
     "@xterm/addon-canvas": "^0.7.0",
     "@xterm/addon-fit": "^0.10.0",
@@ -45,7 +47,6 @@
     "reconnecting-websocket": "^4.4.0"
   },
   "devDependencies": {
-    "prettier": "^3.3.3",
     "@open-wc/building-rollup": "^3.0.2",
     "@rollup/plugin-commonjs": "^26.0.1",
     "@rollup/plugin-terser": "^0.4.4",
@@ -57,6 +58,7 @@
     "express": "^4.19.2",
     "express-ws": "^5.0.2",
     "node-pty": "^1.0.0",
+    "prettier": "^3.3.3",
     "rimraf": "^4.1.2",
     "rollup": "^4.19.0",
     "rollup-plugin-node-polyfills": "^0.2.1",

--- a/server.cjs
+++ b/server.cjs
@@ -183,24 +183,28 @@ function startServer() {
             ws.send(JSON.stringify(msg));
         });
 
-        getOpenableSupervisorPorts().then((ports) => {
-            console.log(`Sending openable ports to client: ${JSON.stringify(ports)}`);
-            const id = crypto.randomUUID();
-            for (const port of ports) {
-                if (port.onOpen === "notify") {
-                    ws.send(
-                        JSON.stringify({
-                            action: "notifyAboutUrl",
-                            data: { url: port.exposed.url, port: port.localPort },
-                            id,
-                        }),
-                    );
-                } else {
-                    ws.send("You should open" + JSON.stringify(port));
-                    ws.send(JSON.stringify({ action: "openUrl", data: port.exposed.url, id }));
+        function sendPortUpdates() {
+            getOpenableSupervisorPorts().then((ports) => {
+                console.log(`Sending openable ports to client: ${JSON.stringify(ports)}`);
+                const id = crypto.randomUUID();
+                for (const port of ports) {
+                    if (port.onOpen === "notify") {
+                        ws.send(
+                            JSON.stringify({
+                                action: "notifyAboutUrl",
+                                data: { url: port.exposed.url, port: port.localPort, name: port.name },
+                                id,
+                            }),
+                        );
+                    } else {
+                        ws.send(JSON.stringify({ action: "openUrl", data: port.exposed.url, id }));
+                    }
                 }
-            }
-        });
+            });
+        }
+
+        // setInterval(sendPortUpdates, 3_000);
+        setTimeout(sendPortUpdates, 2_000);
     });
 
     let clientForExternalMessages = null;

--- a/server.cjs
+++ b/server.cjs
@@ -186,8 +186,8 @@ function startServer() {
         function sendPortUpdates() {
             getOpenableSupervisorPorts().then((ports) => {
                 console.log(`Sending openable ports to client: ${JSON.stringify(ports)}`);
-                const id = crypto.randomUUID();
                 for (const port of ports) {
+                    const id = crypto.randomUUID();
                     if (port.onOpen === "notify") {
                         ws.send(
                             JSON.stringify({

--- a/server.cjs
+++ b/server.cjs
@@ -141,7 +141,7 @@ function startServer() {
         // On initialization, we query the supervisor for ports to be potentially opened
         // {"result":{"ports":[{"localPort":3000,"served":true,"exposed":{"visibility":"private","url":"https://3000-debug-gitpodio-xtermwebide-yq81jdybtx2.ws.dogfood.gitpod.cloud","onExposed":"open_browser","protocol":"http"},"autoExposure":"succeeded","tunneled":{"targetPort":3000,"visibility":"host","clients":{}},"description":"","name":"","onOpen":"open_browser"}]}}
 
-        const endpoint = `http://${process.env.SUPERVISOR_ADDR || 'localhost:22999'}/_supervisor/v1/status/ports`;
+        const endpoint = `http://${process.env.SUPERVISOR_ADDR || "localhost:22999"}/_supervisor/v1/status/ports`;
         const response = await fetch(endpoint, {
             headers: {
                 Accept: "application/json",
@@ -158,7 +158,9 @@ function startServer() {
             throw new Error(`Failed to fetch openable ports from supervisor: ${JSON.stringify(json)}`);
         }
 
-        return json.result.ports.filter(port => port.served && ["open_browser", "open_preview", "notify"].includes(port.onOpen));
+        return json.result.ports.filter(
+            (port) => port.served && ["open_browser", "open_preview", "notify"].includes(port.onOpen),
+        );
     };
 
     const em = new events.EventEmitter();
@@ -181,12 +183,18 @@ function startServer() {
             ws.send(JSON.stringify(msg));
         });
 
-        getOpenableSupervisorPorts().then(ports => {
+        getOpenableSupervisorPorts().then((ports) => {
             console.log(`Sending openable ports to client: ${JSON.stringify(ports)}`);
             const id = crypto.randomUUID();
             for (const port of ports) {
                 if (port.onOpen === "notify") {
-                    ws.send(JSON.stringify({ action: "notifyAboutUrl", data: port.exposed.url, id }))
+                    ws.send(
+                        JSON.stringify({
+                            action: "notifyAboutUrl",
+                            data: { url: port.exposed.url, port: port.localPort },
+                            id,
+                        }),
+                    );
                 } else {
                     ws.send("You should open" + JSON.stringify(port));
                     ws.send(JSON.stringify({ action: "openUrl", data: port.exposed.url, id }));

--- a/src/client.ts
+++ b/src/client.ts
@@ -255,9 +255,13 @@ function handleDisconnected(e: CloseEvent | ErrorEvent, socket: ReconnectingWebS
 
 type OutputReason = "info" | "error";
 
+const dismissButton = document.createElement("button");
+dismissButton.innerText = "Dismiss";
+
 const outputDialog = document.getElementById("output") as HTMLDialogElement;
-const outputContent = document.getElementById("outputContent")!;
+const outputContent = document.getElementById("outputContent") as HTMLParagraphElement;
 const outputReasonInput = document.getElementById("outputReason") as HTMLInputElement;
+const outputForm = outputDialog.querySelector("form") as HTMLFormElement;
 export function output(
     message: string,
     options?: { formActions?: HTMLInputElement[] | HTMLButtonElement[]; reason?: OutputReason },
@@ -265,8 +269,10 @@ export function output(
     if (typeof outputDialog.showModal === "function") {
         outputContent.innerText = message;
         if (options?.formActions) {
+            outputForm.innerHTML = "";
+            outputForm.appendChild(dismissButton);
             for (const action of options.formActions) {
-                outputDialog.querySelector("form")!.appendChild(action);
+                outputForm.appendChild(action);
             }
         }
         outputReasonInput.value = options?.reason ?? "info";

--- a/src/client.ts
+++ b/src/client.ts
@@ -248,7 +248,7 @@ function handleDisconnected(e: CloseEvent | ErrorEvent, socket: ReconnectingWebS
 
 const outputDialog = document.getElementById("output") as HTMLDialogElement;
 const outputContent = document.getElementById("outputContent")!;
-function output(message: string, options?: { formActions: HTMLInputElement[] | HTMLButtonElement[] }) {
+export function output(message: string, options?: { formActions: HTMLInputElement[] | HTMLButtonElement[] }) {
     if (typeof outputDialog.showModal === "function") {
         outputContent.innerText = message;
         if (options?.formActions) {

--- a/src/lib/remote.ts
+++ b/src/lib/remote.ts
@@ -50,7 +50,7 @@ export const initiateRemoteCommunicationChannelSocket = async (protocol: string)
                 break;
             }
             case "notifyAboutUrl": {
-                const { url, port } = messageData.data;
+                const { url, port, name } = messageData.data;
 
                 const openUrlButton = document.createElement("button");
                 openUrlButton.innerText = "Open URL";
@@ -58,6 +58,11 @@ export const initiateRemoteCommunicationChannelSocket = async (protocol: string)
                 openUrlButton.onclick = () => {
                     window.open(url, "_blank");
                 };
+
+                if (name) {
+                    output(`${name} on port ${port} has been opened`, { formActions: [openUrlButton], reason: "info" });
+                    break;
+                }
 
                 output(`Port ${port} has been opened`, { formActions: [openUrlButton], reason: "info" });
                 break;

--- a/src/lib/remote.ts
+++ b/src/lib/remote.ts
@@ -1,4 +1,4 @@
-import { webSocketSettings } from "../client";
+import { output, webSocketSettings } from "../client";
 import { IXtermWindow } from "./types";
 
 declare let window: IXtermWindow;
@@ -42,10 +42,20 @@ export const initiateRemoteCommunicationChannelSocket = async (protocol: string)
             return;
         }
 
-        if (messageData.action === "openUrl") {
-            const url = messageData.data;
-            console.debug(`Opening URL: ${url}`);
-            window.open(url, "_blank");
+        switch (messageData.action) {
+            case "openUrl": {
+                const url = messageData.data;
+                console.debug(`Opening URL: ${url}`);
+                window.open(url, "_blank");
+                break;
+            }
+            case "notifyAboutUrl": {
+                const url = messageData.data;
+                output(url);
+                break
+            }
+            default:
+                console.debug("Unhandled message", messageData)
         }
 
         window.handledMessages.push(messageData.id);

--- a/src/lib/remote.ts
+++ b/src/lib/remote.ts
@@ -50,12 +50,20 @@ export const initiateRemoteCommunicationChannelSocket = async (protocol: string)
                 break;
             }
             case "notifyAboutUrl": {
-                const url = messageData.data;
-                output(url);
-                break
+                const { url, port } = messageData.data;
+
+                const openUrlButton = document.createElement("button");
+                openUrlButton.innerText = "Open URL";
+                openUrlButton.type = "button";
+                openUrlButton.onclick = () => {
+                    window.open(url, "_blank");
+                };
+
+                output(`Port ${port} has been opened`, { formActions: [openUrlButton], reason: "info" });
+                break;
             }
             default:
-                console.debug("Unhandled message", messageData)
+                console.debug("Unhandled message", messageData);
         }
 
         window.handledMessages.push(messageData.id);

--- a/supervisor-helper.ts
+++ b/supervisor-helper.ts
@@ -1,0 +1,122 @@
+import { GitpodClient, GitpodServer, GitpodServiceImpl } from '@gitpod/gitpod-protocol/lib/gitpod-service';
+import { Disposable, DisposableCollection } from '@gitpod/gitpod-protocol/lib/util/disposable';
+import { InfoServiceClient } from '@gitpod/supervisor-api-grpc/lib/info_grpc_pb';
+import { WorkspaceInfoRequest } from '@gitpod/supervisor-api-grpc/lib/info_pb';
+import { NotificationServiceClient } from '@gitpod/supervisor-api-grpc/lib/notification_grpc_pb';
+import { StatusServiceClient } from '@gitpod/supervisor-api-grpc/lib/status_grpc_pb';
+import { PortsStatus, PortsStatusRequest, PortsStatusResponse } from '@gitpod/supervisor-api-grpc/lib/status_pb';
+import { TerminalServiceClient } from '@gitpod/supervisor-api-grpc/lib/terminal_grpc_pb';
+import * as grpc from '@grpc/grpc-js';
+import EventEmitter from 'node:events';
+import * as util from 'util';
+
+export function isGRPCErrorStatus<T extends grpc.status>(err: any, status: T): boolean {
+	return err && typeof err === 'object' && 'code' in err && err.code === status;
+}
+
+// Important:
+// This class should performs all supervisor API calls used outside this module.
+// This is a requirement because mixing Request Objects created in gitpod-web or gitpod-remote with
+// the corresponding service client will cause a runtime error as type checking is done with the
+// `instanceof` operator and they are different modules loaded from different locations
+// E.g.: `Request message serialization failure: Expected argument of type supervisor.PortsStatusRequest`
+// https://penx.medium.com/managing-dependencies-in-a-node-package-so-that-they-are-compatible-with-npm-link-61befa5aaca7
+export class SupervisorConnection {
+	static readonly deadlines = {
+		long: 30 * 1000,
+		normal: 15 * 1000,
+		short: 5 * 1000
+	};
+	private readonly addr = process.env.SUPERVISOR_ADDR || 'localhost:22999';
+	private readonly clientOptions: Partial<grpc.ClientOptions>;
+	readonly metadata = new grpc.Metadata();
+	readonly status: StatusServiceClient;
+	readonly notification: NotificationServiceClient;
+	private readonly info: InfoServiceClient;
+	readonly terminal: TerminalServiceClient;
+
+    readonly onDidChangePortStatus = new EventEmitter();
+
+	constructor(
+		private context: DisposableCollection,
+	) {
+		this.clientOptions = {
+			'grpc.primary_user_agent': `xtermIDE/v1.0.0`,
+		};
+		this.status = new StatusServiceClient(this.addr, grpc.credentials.createInsecure(), this.clientOptions);
+		this.notification = new NotificationServiceClient(this.addr, grpc.credentials.createInsecure(), this.clientOptions);
+		this.info = new InfoServiceClient(this.addr, grpc.credentials.createInsecure(), this.clientOptions);
+		this.terminal = new TerminalServiceClient(this.addr, grpc.credentials.createInsecure(), this.clientOptions);
+
+		this.context.push(Disposable.create(() => {
+            this.onDidChangePortStatus.removeAllListeners();
+        }));
+	}
+
+	private _startObservePortsStatus = false;
+	startObservePortsStatus() {
+		if (this._startObservePortsStatus) {
+			return;
+		}
+		this._startObservePortsStatus = true;
+
+		let run = true;
+		let stopUpdates: Function | undefined;
+		(async () => {
+			while (run) {
+				try {
+					const req = new PortsStatusRequest();
+					req.setObserve(true);
+					const evts = this.status.portsStatus(req, this.metadata);
+					stopUpdates = evts.cancel.bind(evts);
+
+					await new Promise((resolve, reject) => {
+						evts.on('end', resolve);
+						evts.on('error', reject);
+						evts.on('data', (update: PortsStatusResponse) => {
+                            const data = update.getPortsList().map(p => p.toObject());
+							this.onDidChangePortStatus.emit("update", data);
+						});
+					});
+				} catch (err) {
+					if (!isGRPCErrorStatus(err, grpc.status.CANCELLED)) {
+						console.error('cannot maintain connection to supervisor', err);
+					}
+				} finally {
+					stopUpdates = undefined;
+				}
+				await new Promise(resolve => setTimeout(resolve, 1000));
+			}
+		})();
+		this.context.push({
+			dispose() {
+				run = false;
+				if (stopUpdates) {
+					stopUpdates();
+				}
+			}
+		});
+	}
+
+	async getWorkspaceInfo() {
+		const response = await util.promisify(this.info.workspaceInfo.bind(this.info, new WorkspaceInfoRequest(), this.metadata, {
+			deadline: Date.now() + SupervisorConnection.deadlines.long
+		}))();
+		return response.toObject();
+	}
+}
+
+type UsedGitpodFunction = ['getWorkspace', 'openPort', 'stopWorkspace', 'setWorkspaceTimeout', 'getWorkspaceTimeout', 'getLoggedInUser', 'takeSnapshot', 'waitForSnapshot', 'controlAdmission', 'sendHeartBeat', 'trackEvent', 'getTeams'];
+type Union<Tuple extends any[], Union = never> = Tuple[number] | Union;
+export type GitpodConnection = Omit<GitpodServiceImpl<GitpodClient, GitpodServer>, 'server'> & {
+	server: Pick<GitpodServer, Union<UsedGitpodFunction>>;
+};
+
+
+const supervisor = new SupervisorConnection(new DisposableCollection());
+// supervisor.startObservePortsStatus();
+console.log("Supervisor connection started");
+console.log(await supervisor.getWorkspaceInfo());
+supervisor.onDidChangePortStatus.on("update", (ports) => {
+    console.log("Ports updated", ports);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1249,6 +1249,32 @@
     vscode-ws-jsonrpc "^0.2.0"
     ws "^7.4.6"
 
+"@gitpod/supervisor-api-grpc@0.1.5-main-gha.10852":
+  version "0.1.5-main-gha.10852"
+  resolved "https://registry.yarnpkg.com/@gitpod/supervisor-api-grpc/-/supervisor-api-grpc-0.1.5-main-gha.10852.tgz#83755a5c0539fe9482a141351a7441057e7d352c"
+  integrity sha512-/OWTpEVZMYut0IbAH50sx6yVYeQB9TKZu+3kgkGiwT6LihgrH98BXteFT77yrlpKTHmAuvdoN3XJCGGPhfePRA==
+  dependencies:
+    "@grpc/grpc-js" "^1.3.7"
+    google-protobuf "^3.19.1"
+
+"@grpc/grpc-js@^1.11.1", "@grpc/grpc-js@^1.3.7":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.11.1.tgz#a92f33e98f1959feffcd1b25a33b113d2c977b70"
+  integrity sha512-gyt/WayZrVPH2w/UTLansS7F9Nwld472JxxaETamrM8HNlsa+jSLNyKAZmhxI2Me4c3mQHFiS1wWHDY1g1Kthw==
+  dependencies:
+    "@grpc/proto-loader" "^0.7.13"
+    "@js-sdsl/ordered-map" "^4.4.2"
+
+"@grpc/proto-loader@^0.7.13":
+  version "0.7.13"
+  resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.7.13.tgz#f6a44b2b7c9f7b609f5748c6eac2d420e37670cf"
+  integrity sha512-AiXO/bfe9bmxBjxxtYxFAXGZvMaN5s8kO+jBHAJCON8rJoB5YS/D6X7ZNc6XQkuHNmyl4CYaMI1fJ/Gn27RGGw==
+  dependencies:
+    lodash.camelcase "^4.3.0"
+    long "^5.0.0"
+    protobufjs "^7.2.5"
+    yargs "^17.7.2"
+
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
@@ -1300,6 +1326,11 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
+
+"@js-sdsl/ordered-map@^4.4.2":
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz#9299f82874bab9e4c7f9c48d865becbfe8d6907c"
+  integrity sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -1387,6 +1418,59 @@
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
+
+"@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
+  integrity sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==
+
+"@protobufjs/base64@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/base64/-/base64-1.1.2.tgz#4c85730e59b9a1f1f349047dbf24296034bb2735"
+  integrity sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==
+
+"@protobufjs/codegen@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@protobufjs/codegen/-/codegen-2.0.4.tgz#7ef37f0d010fb028ad1ad59722e506d9262815cb"
+  integrity sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==
+
+"@protobufjs/eventemitter@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz#355cbc98bafad5978f9ed095f397621f1d066b70"
+  integrity sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==
+
+"@protobufjs/fetch@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/fetch/-/fetch-1.1.0.tgz#ba99fb598614af65700c1619ff06d454b0d84c45"
+  integrity sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.1"
+    "@protobufjs/inquire" "^1.1.0"
+
+"@protobufjs/float@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/float/-/float-1.0.2.tgz#5e9e1abdcb73fc0a7cb8b291df78c8cbd97b87d1"
+  integrity sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==
+
+"@protobufjs/inquire@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/inquire/-/inquire-1.1.0.tgz#ff200e3e7cf2429e2dcafc1140828e8cc638f089"
+  integrity sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==
+
+"@protobufjs/path@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/path/-/path-1.1.2.tgz#6cc2b20c5c9ad6ad0dccfd21ca7673d8d7fbf68d"
+  integrity sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==
+
+"@protobufjs/pool@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/pool/-/pool-1.1.0.tgz#09fd15f2d6d3abfa9b65bc366506d6ad7846ff54"
+  integrity sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==
+
+"@protobufjs/utf8@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
+  integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
 "@rollup/plugin-babel@^5.2.0":
   version "5.3.1"
@@ -1603,6 +1687,13 @@
   version "4.17.7"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.17.7.tgz#2f776bcb53adc9e13b2c0dfd493dfcbd7de43612"
   integrity sha512-8wTvZawATi/lsmNu10/j2hk1KEP0IvjubqPE3cu1Xz7xfXXt5oCq3SNUz4fMIP4XGF9Ky+Ue2tBA3hcS7LSBlA==
+
+"@types/node@>=13.7.0":
+  version "20.14.12"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.14.12.tgz#129d7c3a822cb49fc7ff661235f19cfefd422b49"
+  integrity sha512-r7wNXakLeSsGT0H1AU863vS2wa5wBOK4bWMjZz2wj+8nBx+m5PeIn0k8AloSLpRuiwdRQZwarZqHE4FNArPuJQ==
+  dependencies:
+    undici-types "~5.26.4"
 
 "@types/node@^20.14.11":
   version "20.14.11"
@@ -2200,6 +2291,15 @@ clean-css@^5.3.1, clean-css@~5.3.2:
   dependencies:
     source-map "~0.6.0"
 
+cliui@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
+  integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.1"
+    wrap-ansi "^7.0.0"
+
 clone@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
@@ -2680,7 +2780,7 @@ esbuild@^0.21.3:
     "@esbuild/win32-ia32" "0.21.5"
     "@esbuild/win32-x64" "0.21.5"
 
-escalade@^3.1.2:
+escalade@^3.1.1, escalade@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.2.tgz#54076e9ab29ea5bf3d8f1ed62acffbb88272df27"
   integrity sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==
@@ -2976,6 +3076,11 @@ gensync@^1.0.0-beta.2:
   version "1.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
   integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
+
+get-caller-file@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
+  integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
 get-intrinsic@^1.1.3, get-intrinsic@^1.2.1, get-intrinsic@^1.2.3, get-intrinsic@^1.2.4:
   version "1.2.4"
@@ -3597,6 +3702,11 @@ lightningcss@^1.24.0:
     lightningcss-linux-x64-musl "1.25.1"
     lightningcss-win32-x64-msvc "1.25.1"
 
+lodash.camelcase@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+  integrity sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==
+
 lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
@@ -3621,6 +3731,11 @@ long@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/long/-/long-2.4.0.tgz#9fa180bb1d9500cdc29c4156766a1995e1f4524f"
   integrity sha512-ijUtjmO/n2A5PaosNG9ZGDsQ3vxJg7ZW8vsY8Kp0f2yIZWhSJvjmegV7t+9RPQKxKrvj8yKGehhS+po14hPLGQ==
+
+long@^5.0.0:
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/long/-/long-5.2.3.tgz#a3ba97f3877cf1d778eccbcb048525ebb77499e1"
+  integrity sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==
 
 loose-envify@^1.1.0:
   version "1.4.0"
@@ -4030,6 +4145,24 @@ promise-stream-reader@^1.0.1:
   resolved "https://registry.yarnpkg.com/promise-stream-reader/-/promise-stream-reader-1.0.1.tgz#4e793a79c9d49a73ccd947c6da9c127f12923649"
   integrity sha512-Tnxit5trUjBAqqZCGWwjyxhmgMN4hGrtpW3Oc/tRI4bpm/O2+ej72BB08l6JBnGQgVDGCLvHFGjGgQS6vzhwXg==
 
+protobufjs@^7.2.5:
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.3.2.tgz#60f3b7624968868f6f739430cfbc8c9370e26df4"
+  integrity sha512-RXyHaACeqXeqAKGLDl68rQKbmObRsTIn4TYVUUug1KfS47YWCo5MacGITEryugIgZqORCvJWEk4l449POg5Txg==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.4"
+    "@protobufjs/eventemitter" "^1.1.0"
+    "@protobufjs/fetch" "^1.1.0"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/inquire" "^1.1.0"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.0"
+    "@types/node" ">=13.7.0"
+    long "^5.0.0"
+
 proxy-addr@~2.0.7:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.7.tgz#f19fe69ceab311eeb94b42e70e8c2070f9ba1025"
@@ -4196,6 +4329,11 @@ remove-trailing-slash@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/remove-trailing-slash/-/remove-trailing-slash-0.1.1.tgz#be2285a59f39c74d1bce4f825950061915e3780d"
   integrity sha512-o4S4Qh6L2jpnCy83ysZDau+VORNvnFw07CKSAymkd6ICNVEPisMyzlc00KlvvicsxKck94SEwhDnMNdICzO+tA==
+
+require-directory@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
+  integrity sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==
 
 require-from-string@^2.0.2:
   version "2.0.2"
@@ -4528,7 +4666,7 @@ string-template@~0.2.1:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
-string-width@^4.1.0:
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -5170,6 +5308,15 @@ workbox-window@7.1.0:
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
 
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrap-ansi@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-8.1.0.tgz#56dc22368ee570face1b49819975d9b9a5ead214"
@@ -5199,6 +5346,11 @@ xtend@^4.0.0, xtend@~4.0.0:
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
   integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
+y18n@^5.0.5:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
+  integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
 yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
@@ -5208,3 +5360,21 @@ yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+
+yargs-parser@^21.1.1:
+  version "21.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
+  integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
+
+yargs@^17.7.2:
+  version "17.7.2"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
+  integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"


### PR DESCRIPTION
## Description

This change adds support for configuring what happens when a port gets exposed through the supervisor. This adds support for gitpod yamls like this:

```yaml
image:
    file: Dockerfile

tasks:
    - name: Launch JupyterLab
      init: pip install jupyterlab
      command:
        jupyter lab --port 8888 --ServerApp.token='' --ServerApp.allow_remote_access=true --no-browser;
        gp timeout extend
  
ports:
    - port: 8888
      name: JupyterLab
      onOpen: notify

```

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to ENT-505.

## How to test

Open a workspace with this PR. There should be an example configuration ready and applied.
