### PR TITLE
feat: Set onbeforeunload to avoid losing the current terminal session with Ctrl+W

### DIFF
--- a/server.cjs
+++ b/server.cjs
@@ -182,7 +182,15 @@ function startServer() {
             }
         }
 
-        sendPortUpdates();
+        async function init() {
+            if (process.env["XTERM_CONFIRM_BROWSER_EXIT"] === "true") {
+                ws.send(JSON.stringify({ action: "confirmExit" }));
+            }
+
+            sendPortUpdates();
+        }
+
+        init();
     });
 
     let clientForExternalMessages = null;

--- a/src/client.ts
+++ b/src/client.ts
@@ -205,6 +205,12 @@ async function createTerminal(
     const debouncedUpdateTerminalSize = debounce(() => updateTerminalSize(term), 200, { trailing: true });
     window.onresize = () => debouncedUpdateTerminalSize();
 
+    // Ask for confirmation before closing the current terminal session
+    window.onbeforeunload = (event) => {
+        event.preventDefault();
+	event.returnValue = "really?"; // supporting legacy browsers
+    };
+
     // Register the onclick event for the reconnect button
     reconnectButton.onclick = () => terminalSocket.reconnect();
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -205,12 +205,6 @@ async function createTerminal(
     const debouncedUpdateTerminalSize = debounce(() => updateTerminalSize(term), 200, { trailing: true });
     window.onresize = () => debouncedUpdateTerminalSize();
 
-    // Ask for confirmation before closing the current terminal session
-    window.onbeforeunload = (event) => {
-        event.preventDefault();
-	event.returnValue = "really?"; // supporting legacy browsers
-    };
-
     // Register the onclick event for the reconnect button
     reconnectButton.onclick = () => terminalSocket.reconnect();
 

--- a/src/lib/remote.ts
+++ b/src/lib/remote.ts
@@ -66,6 +66,13 @@ export const initiateRemoteCommunicationChannelSocket = async (protocol: string)
                 output(`Port ${port} has been opened`, { formActions: [openUrlButton], reason: "info" });
                 break;
             }
+            case "confirmExit": {
+                // Ask for confirmation before closing the current terminal session
+                window.onbeforeunload = (e: BeforeUnloadEvent) => {
+                    e.preventDefault();
+                    e.returnValue = "Are you sure you want to close the terminal?";
+                };
+            }
             default:
                 console.debug("Unhandled message", messageData);
         }


### PR DESCRIPTION
## Description
As an Emacs user (and co-maintainer of several packages), I extensively use Gitpod Terminal Browser in multiple occasions. Gitpod Terminal is a very nice tool!
— even if the README states that "it is not ready for production use", I guess it's pretty close 👍

Motivation of this PR: given the Ctrl+W is a very typical Emacs shortcut that **must** be avoided when using Gitpod (because it amounts to stopping the workspace and losing the ambient session), this small feature appears to be very important for Gitpod+Terminal users.

BTW I followed advice from https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event:
> The dialog can be triggered in the following ways:
> * Calling the event object's [preventDefault()](https://developer.mozilla.org/en-US/docs/Web/API/Event/preventDefault) method.
> * Setting the event object's [returnValue](https://developer.mozilla.org/en-US/docs/Web/API/BeforeUnloadEvent/returnValue) property to a non-empty string value or any other [truthy](https://developer.mozilla.org/en-US/docs/Glossary/Truthy) value.
> * Returning any truthy value from the event handler function, e.g. return "string". Note that this only works when the function is attached via the onbeforeunload property, not the [addEventListener()](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener) method. This behavior is consistent across modern versions of Firefox, Safari, and Chrome.
> 
> The last two mechanisms are legacy features; **best practice is to trigger the dialog by invoking preventDefault() on the event object, while also setting returnValue to support legacy cases.**

Then tested the feature successfully on Firefox ESR (under Debian Stable).

Cc @filiptronicek @mustard-mh @loujaybee @axonasif WDYT?

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #gitpod-io/gitpod#18416

## How to test

* Open a gitpod workspace from the branch:
  https://gitpod.io/new/?autostart=false&useLatest=true&editor=xterm#https://github.com/gitpod-io/xterm-web-ide/pull/23
* Run `./validate.sh` (after applying #24)
* Open the accompanying `https://debug-…` gitpod instance (and click Dismiss on the dialog)
* Open the browser's developer console and check that `window.onbeforeunload` is not `null`

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/hold