### PR TITLE
fix: validate.sh was incomplete for testing #23

### DIFF
--- a/validate.sh
+++ b/validate.sh
@@ -11,7 +11,7 @@ tar -xvf /workspace/rebuild/xterm.tar -C /workspace/rebuild/
 find /workspace/rebuild/ -name layer.tar -exec tar -xvf {} -C /workspace/rebuild/ \;
 
 cp /workspace/rebuild/ide/supervisor-ide-config.json /ide/
-rm /ide/xterm && true
+rm -fr /ide/xterm || true
 ln -s /workspace/rebuild/ide/xterm /ide/xterm
 echo "xterm: linked in /ide"
 


### PR DESCRIPTION
## Description

`./validate.sh` currently fails on a fresh gitpod workspace with:

```
rm: cannot remove '/ide/xterm': Is a directory
ln: failed to create symbolic link '/ide/xterm/xterm': File exists
```

## Related Issue(s)
Fixes a minor issue

## How to test

Run `validate.sh` on a fresh gitpod workspace

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/hold